### PR TITLE
[ Fix #1 ] update to Agda-2.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Revision history for agda-bench
 
+## 1.1.0
+
+* Works with Agda 2.6.2.
+
 ## 1.0.0  -- 2018-10-15
 
 * First version.
+* For Agda >= 2.5.4 && < 2.6.2.

--- a/agda-bench.cabal
+++ b/agda-bench.cabal
@@ -1,5 +1,5 @@
 name:                agda-bench
-version:             1.0.0
+version:             1.1.0
 license:             BSD3
 license-file:        LICENSE
 author:              Ulf Norell
@@ -23,10 +23,10 @@ source-repository head
 
 executable agda-bench
   main-is:             Main.hs
-  build-depends:       base >=4.10 && <4.15,
-                       criterion >=1.4,
-                       Agda >=2.5.4 && <2.7,
-                       unordered-containers >= 0.2.5.0 && < 0.3
+  build-depends:       base                 >= 4.10    && < 4.15
+                     , Agda                 >= 2.6.2   && < 2.7
+                     , criterion            >= 1.4
+                     , mtl                  >= 2.2.2   && < 2.3
+                     , unordered-containers >= 0.2.5.0 && < 0.3
   ghc-options:         -rtsopts -with-rtsopts=-M8G
   default-language:    Haskell2010
-

--- a/agda-bench.cabal
+++ b/agda-bench.cabal
@@ -23,8 +23,8 @@ source-repository head
 
 executable agda-bench
   main-is:             Main.hs
-  build-depends:       base                 >= 4.10    && < 4.15
-                     , Agda                 >= 2.6.2   && < 2.7
+  build-depends:       base                 >= 4.10    && < 4.16
+                     , Agda                 >= 2.5.4   && < 2.7
                      , criterion            >= 1.4
                      , mtl                  >= 2.2.2   && < 2.3
                      , unordered-containers >= 0.2.5.0 && < 0.3


### PR DESCRIPTION
[ Fix #1 ] update to Agda-2.6.2

This PR hasn't been build nor tested, having trouble to depend on Agda-2.6.2 with v2-cabal.
I am submitting it anyway, maybe you manage to build it with v1-cabal, @UlfNorell.  (I got into cabal hell there.)