### PR TITLE
[ update ] Make agda-bench compatible with 2.6.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 dist
+dist-newstyle
+.stack-work

--- a/Main.hs
+++ b/Main.hs
@@ -1,10 +1,14 @@
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts, DeriveGeneric, DeriveAnyClass #-}
 
 module Main where
+
+import GHC.Generics (Generic)
+import Control.DeepSeq
 
 import Control.Monad
 import Control.Monad.Except
 import Control.Monad.IO.Class
+
 import Criterion.Main
 import Data.List
 import qualified Data.HashMap.Strict as HMap
@@ -38,7 +42,8 @@ data Options = Options { criterionOptions :: [String]
                        , customBench      :: [String]
                        , typeCheckBench   :: [(String, String)]
                        , useCallByName    :: Bool
-                       , fullNormalForm   :: Bool }
+                       , fullNormalForm   :: Bool
+                       } deriving (Generic, NFData)
 
 defaultOptions :: Options
 defaultOptions = Options [] Nothing [] [] False False

--- a/agda-bench.cabal
+++ b/agda-bench.cabal
@@ -26,6 +26,8 @@ executable agda-bench
   build-depends:       base                 >= 4.10    && < 4.16
                      , Agda                 >= 2.5.4   && < 2.7
                      , criterion            >= 1.4
+                     -- same as Agda 2.6.2
+                     , deepseq              >= 1.4.2.0
                      , mtl                  >= 2.2.2   && < 2.3
                      , unordered-containers >= 0.2.5.0 && < 0.3
   ghc-options:         -rtsopts -with-rtsopts=-M8G


### PR DESCRIPTION
Since Agda 2.6.2, the option type needs to be an instance of `NFData`. 